### PR TITLE
Add a check if currentImageUrl is set when using arrow keys

### DIFF
--- a/caesar-lightbox.js
+++ b/caesar-lightbox.js
@@ -37,6 +37,8 @@
 
             // Previous and next. Sets the currentImageUrl based on the position of the currentImageUrl in the imageUrls array. If index is at the end of the array, reset if to browse around
             loadPrevious(){
+                if(!this.currentImageUrl)
+                    return;
                 let previousIndex = imageUrls.indexOf(this.currentImageUrl)-1
                 if(previousIndex == -1){
                     previousIndex = imageUrls.length-1
@@ -46,6 +48,8 @@
             },
 
             loadNext(){
+                if(!this.currentImageUrl)
+                    return;
                 let nextIndex = imageUrls.indexOf(this.currentImageUrl)+1
                 if(nextIndex == imageUrls.length){
                     nextIndex = 0

--- a/example/caesar-lightbox.js
+++ b/example/caesar-lightbox.js
@@ -37,6 +37,8 @@
 
             // Previous and next. Sets the currentImageUrl based on the position of the currentImageUrl in the imageUrls array. If index is at the end of the array, reset if to browse around
             loadPrevious(){
+                if(!this.currentImageUrl)
+                    return;
                 let previousIndex = imageUrls.indexOf(this.currentImageUrl)-1
                 if(previousIndex == -1){
                     previousIndex = imageUrls.length-1
@@ -46,6 +48,8 @@
             },
 
             loadNext(){
+                if(!this.currentImageUrl)
+                    return;
                 let nextIndex = imageUrls.indexOf(this.currentImageUrl)+1
                 if(nextIndex == imageUrls.length){
                     nextIndex = 0


### PR DESCRIPTION
Before this fix pressing the right arrow would bring up the lightbox. This made using forms cumbersome on some pages. And was probably unexpected behavior.